### PR TITLE
Move build directive into docker-compose-dev.yml

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,6 +4,12 @@ x-images:
     command: 'sh -c "while true;do echo notstarted;sleep 65000;done"'
     entrypoint: 'sh -c "while true;do echo notstarted;sleep 65000;done"'
     restart: "no"
+x-django: &django
+  image: terralego/opp-back:latest
+  build:
+    context: "."
+    args:
+      TAG: "${IMAGE_TAG:-latest}"
 services:
   nginx:
     environment:
@@ -13,7 +19,10 @@ services:
     - "80:80"
     - "443:443"
   backup: {<<: [ *bypass ]}
+  cron:
+    <<: [ *django ]
   django:
+    <<: [ *django ]
     stdin_open: true
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,6 @@ x-images:
   django: &django
     <<: [ *env ]
     tty: true
-    build:
-      context: "."
-      args:
-        TAG: "${IMAGE_TAG:-latest}"
     depends_on:
     - db
     - redis
@@ -81,7 +77,6 @@ services:
     - SUPERVISORD_CONFIGS=/etc/supervisor.d/cron /etc/supervisor.d/nginx /etc/supervisor.d/rsyslog
   django:
     <<: [ *django ]
-    image: terralego/opp-back:latest
   cron:
     <<: [ *django ]
     command:


### PR DESCRIPTION
That way we ensure the image is never rebuilded when using
docker-compose.yml + docker-compose-prod.yml in production environment.